### PR TITLE
ci: add # main anchor comment to cffnpwr/actions refs for renovate tracking

### DIFF
--- a/.github/workflows/flake-check.yaml
+++ b/.github/workflows/flake-check.yaml
@@ -15,6 +15,6 @@ concurrency:
 permissions: {}
 jobs:
   flake-check:
-    uses: cffnpwr/actions/.github/workflows/flake-check.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/flake-check.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
     permissions:
       contents: read

--- a/.github/workflows/github-actions-lint.yaml
+++ b/.github/workflows/github-actions-lint.yaml
@@ -14,6 +14,6 @@ concurrency:
 permissions: {}
 jobs:
   lint:
-    uses: cffnpwr/actions/.github/workflows/github-actions-lint.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/github-actions-lint.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
     permissions:
       contents: read

--- a/.github/workflows/semantic-pr-title.yaml
+++ b/.github/workflows/semantic-pr-title.yaml
@@ -14,4 +14,4 @@ concurrency:
 permissions: {}
 jobs:
   semantic-pr-title:
-    uses: cffnpwr/actions/.github/workflows/semantic-pr-title.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/semantic-pr-title.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main

--- a/.github/workflows/status-check.yaml
+++ b/.github/workflows/status-check.yaml
@@ -14,8 +14,10 @@ concurrency:
 permissions: {}
 jobs:
   status-check:
-    uses: cffnpwr/actions/.github/workflows/status-check.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/status-check.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
     permissions:
+      contents: read
+      actions: read
       pull-requests: read
       checks: read
       statuses: read


### PR DESCRIPTION
## 概要

`cffnpwr/actions` 再利用ワークフローの生SHA pin（コメント無し）がrenovateに追跡されず、main更新へのdigest更新PRが生成されない問題を修正する。対象4ファイルの `@<sha>` 参照に `# main` アンカーコメントを付与し、renovateの追跡対象へ復帰させる。

Closes #144

## 変更内容

- `flake-check.yaml` / `github-actions-lint.yaml` / `semantic-pr-title.yaml` / `status-check.yaml` の `cffnpwr/actions/...@<sha>` 参照に `# main` を付与
- `status-check.yaml` の呼び出しに `contents: read` と `actions: read` を追加

## 影響

- renovateがdigest更新でmain HEADへ追従できるようになる。
- `status-check.yaml` はdigest更新後もStatus checkが起動失敗しないよう権限を追加した。
- renovateのDependency Dashboard再スキャン・digest更新PR生成はマージ後にrenovate側で反映されるため、本PRでは検証できない。
