### PR TITLE
ci: fix semantic PR title startup failure and zizmor cache-poisoning error

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version: "24.18.0"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
       - name: Install dependencies
         run: nix develop .#publish --command bun install --frozen-lockfile
       - name: Build

--- a/.github/workflows/semantic-pr-title.yaml
+++ b/.github/workflows/semantic-pr-title.yaml
@@ -15,3 +15,5 @@ permissions: {}
 jobs:
   semantic-pr-title:
     uses: cffnpwr/actions/.github/workflows/semantic-pr-title.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
+    permissions:
+      pull-requests: read


### PR DESCRIPTION
## 概要

CIの2件の不具合を修正する。

1. `Semantic PR title` ワークフローが全PRで `startup_failure` となり検査が実行されない問題
2. `cffnpwr/actions` のdigest更新PR (#159) で `lint / Run zizmor` が `cache-poisoning` (high) により失敗する問題

## 変更内容

- `semantic-pr-title.yaml`: 再利用ワークフロー呼び出しjobに `pull-requests: read` を付与
- `publish.yaml`: `actions/setup-node` に `package-manager-cache: false` を指定

## 影響

- `Semantic PR title` がPRのチェックとして実行されるようになる。現状は全PRで起動失敗のため、PRタイトルのConventional Commit検査が機能していない。
- `cffnpwr/actions` のdigestを `8e44912` へ更新しても zizmor が通るようになる。
- `publish.yaml` の依存解決はbun + nixで行っており、setup-nodeのパッケージマネージャキャッシュは元々使用していないため、公開処理の挙動に変化はない。
- 破壊的変更なし。

### 原因

1について、呼び出し側はトップレベルで `permissions: {}` を指定しjob側で権限を付与していない一方、呼び出される `cffnpwr/actions/.github/workflows/semantic-pr-title.yaml` のjobは `pull-requests: read` を要求する。再利用ワークフローは呼び出し元から渡された `GITHUB_TOKEN` の権限を縮小できるが昇格はできない（[Reusable workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/reusable-workflows)）ため、ワークフローが起動段階で無効になっていた。#158 で `status-check.yaml` に対して行った修正と同種で、`semantic-pr-title.yaml` に取り残されていた。

2について、`release: published` を契機とするワークフローでキャッシュが既定有効な `actions/setup-node` を使う構成が zizmor の [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) 検出対象となる。同auditが `actions/setup-node` 向けのopt-out入力として挙げている `package-manager-cache: false` を指定して解消する。
