### PR TITLE
ci: :wrench: restore cancel-in-progress on the release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,9 +5,8 @@ on:
       - main
 
 concurrency:
-  group: >-
-    ${{ github.workflow }}- ${{ github.repository }}- ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions: {}
 


### PR DESCRIPTION
## 概要

`release-please.yaml` の `concurrency` を #170 以前の状態に戻しました。

- `cancel-in-progress` を `false` → `true`
- `group` の折りたたみブロック（`>-`）を1行に変更

## 背景・理由

#170 で `cancel-in-progress: false` にしたのは、publishが同一workflowに入ったことで実行中のrunが後続pushでキャンセルされるのを防ぐ意図でした。この変更は不要でした。

`push` イベントでは `github.head_ref` が空です（[GitHub Docs](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts): "This property is only available when the event that triggers a workflow run is either `pull_request` or `pull_request_target`."）。したがって `||` が `github.run_id` にフォールバックし、groupはrunごとに一意になります。groupを共有するrunが存在しない以上、`cancel-in-progress` の値にかかわらずキャンセルは発生しません。

`group` を1行にしたのは、`>-` の折りたたみブロックが改行を空白に変換するためです。従来の値は `Release Please- cffnpwr/result-ts- <run_id>` のようにハイフンの後ろに空白が入っていました。group文字列としては一意性に影響しませんが、意図した形ではないため揃えました。

## 影響

- 挙動の変化なし。groupがrunごとに一意である以上、`cancel-in-progress` はどちらの値でも効きません
- `group` の値からハイフン後の空白が消えます。concurrency groupの識別子が変わるだけで、一意性は保たれます
- 破壊的変更なし

## 関連

- #170
