### PR TITLE
ci: :wrench: migrate create-github-app-token to client-id

### DIFF
--- a/.agents/docs/workflows/release.md
+++ b/.agents/docs/workflows/release.md
@@ -67,12 +67,12 @@ Runs only after both publish jobs succeed. Flips the draft release to public wit
 
 If either registry fails, this job is skipped and the release stays a draft. Fix the cause and re-run the failed jobs; the draft is published once they pass.
 
-## Required GitHub Secrets
+## Required GitHub Secrets and Variables
 
-| Secret | Used by |
-|---|---|
-| `RELEASE_APP_ID` | `release-please.yaml` — GitHub App for creating the release PR and publishing the draft release |
-| `RELEASE_PRIVATE_KEY` | `release-please.yaml` — GitHub App private key |
+| Name | Kind | Used by |
+|---|---|---|
+| `RELEASE_CLIENT_ID` | Variable | `release-please.yaml` — GitHub App client ID for creating the release PR and publishing the draft release |
+| `RELEASE_PRIVATE_KEY` | Secret | `release-please.yaml` — GitHub App private key |
 
 These are already configured. Do not modify or rotate them without coordinating with the repo owner.
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-metadata: read
           permission-contents: write
@@ -115,7 +115,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write
 


### PR DESCRIPTION
## What
`.github/workflows/release-please.yaml` の `actions/create-github-app-token` で、`app-id: ${{ secrets.RELEASE_APP_ID }}` を `client-id: ${{ vars.RELEASE_CLIENT_ID }}` に置き換えた（2箇所）。
あわせて `.agents/docs/workflows/release.md` の記述を更新した。

## Why
`app-id` は非推奨で、`action.yml` に `deprecationMessage: "Use 'client-id' instead."` が付いている。非推奨入力が削除された時点でリリースパイプラインが止まる。

## Impact
- リポジトリ変数 `RELEASE_CLIENT_ID` を参照する。値は GitHub App `cffnpwr-release-bot` の Client ID で、設定済み。App ID とは別の識別子
- シークレット `RELEASE_APP_ID` はこのPRのマージと動作確認の後に削除する
- `private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}` は変更していない

Closes #184
